### PR TITLE
[ADD] 10026 python solution

### DIFF
--- a/graph/10026/main.py
+++ b/graph/10026/main.py
@@ -1,0 +1,43 @@
+import sys
+sys.setrecursionlimit(10000)
+
+dx = [-1, 0, 1, 0]
+dy = [0, 1, 0, -1]
+
+
+def dfs(row, col):
+    visited[row][col] = True
+    for k in range(4):
+        nx = col + dx[k]
+        ny = row + dy[k]
+
+        if 0 <= nx < n and 0 <= ny < n and not visited[ny][nx] and grid[ny][nx] == grid[row][col]:
+            dfs(ny, nx)
+
+
+n = int(input())
+
+grid = [list(input()) for _ in range(n)]
+visited = [[False] * n for _ in range(n)]
+
+cnt1 = 0
+for i in range(n):
+    for j in range(n):
+        if not visited[i][j]:
+            dfs(i, j)
+            cnt1 += 1
+
+for i in range(n):
+    for j in range(n):
+        if grid[i][j] == 'G':
+            grid[i][j] = 'R'
+
+visited = [[False] * n for _ in range(n)]
+cnt2 = 0
+for i in range(n):
+    for j in range(n):
+        if not visited[i][j]:
+            dfs(i, j)
+            cnt2 += 1
+
+print(cnt1, cnt2)


### PR DESCRIPTION
# 백준 솔루션

## 문제 번호
[적록색약](https://www.acmicpc.net/problem/10026)

## 백준 아이디
[01ucir](https://www.acmicpc.net/user/01ucir)

## 해결방법
1. 색약이 아닌 경우, 주어진 그리드 그대로 dfs를 진행하며 구역의 수를 센다.
2. 색약인 경우, G를 R로 모두 바꿔준 뒤 dsf를 진행한다.
3. dfs(i,j)는 grid[i][j]의 방문여부를 True로 변경하고, 
    아직 방문하지 않은 인접한 노드 중 같은 색인 노드로 이동하여 다시 dfs를 수행한다. 
* 백준 온라인 저지의 경우 재귀의 깊이가 기본 1000으로 설정되어 있으므로 
    sys.setrecursionlimit(10000)를 통해 재귀의 깊이를 더 깊게 설정해야 통과된다.
